### PR TITLE
BetterHome

### DIFF
--- a/src/components/SessionsList/SessionListGroup.js
+++ b/src/components/SessionsList/SessionListGroup.js
@@ -24,10 +24,6 @@ import moment from 'moment';
 import './SessionsList.css';
 
 class SessionsListGroup extends Component {
-  constructor(props) {
-    super(props);
-  }
-
   renderEmail = speaker => {
     if (speaker.handle && speaker.domain) {
       const address = speaker.handle + '@' + speaker.domain;
@@ -277,7 +273,6 @@ class SessionsListGroup extends Component {
     const n_sessions = session_render_list.length;
     let session_render_wrapper = <div>{session_render_list}</div>;
     if (n_sessions > this.props.max_sessions) {
-      var n_hidden = this.props.sessions.length - this.props.max_sessions;
       session_render_list = session_render_list.slice(
         0,
         this.props.max_sessions

--- a/src/components/SessionsList/SessionListGroup.js
+++ b/src/components/SessionsList/SessionListGroup.js
@@ -26,9 +26,6 @@ import './SessionsList.css';
 class SessionsListGroup extends Component {
   constructor(props) {
     super(props);
-    this.state = {
-      max_sessions: 5,
-    };
   }
 
   renderEmail = speaker => {
@@ -279,28 +276,13 @@ class SessionsListGroup extends Component {
 
     const n_sessions = session_render_list.length;
     let session_render_wrapper = <div>{session_render_list}</div>;
-    if (n_sessions > this.state.max_sessions) {
-      var n_hidden = this.props.sessions.length - this.state.max_sessions;
+    if (n_sessions > this.props.max_sessions) {
+      var n_hidden = this.props.sessions.length - this.props.max_sessions;
       session_render_list = session_render_list.slice(
         0,
-        this.state.max_sessions
+        this.props.max_sessions
       );
-      session_render_wrapper = (
-        <div>
-          {session_render_list}
-          <Button
-            color="primary"
-            onClick={e => {
-              this.setState({
-                max_sessions: this.state.max_sessions + 5,
-              });
-            }}
-          >
-            {' '}
-            Show More ({n_hidden} Hidden){' '}
-          </Button>
-        </div>
-      );
+      session_render_wrapper = <div>{session_render_list}</div>;
     }
     return session_render_wrapper;
   };

--- a/src/components/SessionsList/SessionsList.css
+++ b/src/components/SessionsList/SessionsList.css
@@ -3,6 +3,10 @@
   text-align: left;
 }
 
+.center-align {
+  text-align: center;
+}
+
 .gray {
   color: gray;
 }

--- a/src/components/SessionsList/SessionsList.js
+++ b/src/components/SessionsList/SessionsList.js
@@ -1,11 +1,20 @@
 import React, { Component } from 'react';
-import { Container, Row, Col, Form, FormGroup, Label, Input } from 'reactstrap';
+import {
+  Button,
+  Container,
+  Row,
+  Col,
+  Form,
+  FormGroup,
+  Label,
+  Input,
+} from 'reactstrap';
 import moment from 'moment';
 
 import Fuse from 'fuse.js';
 import './SessionsList.css';
 
-import session_data from '../../sessions.json'; // in future, load from S3 or similar
+import session_data from '../../sessions.json';
 import SessionListGroup from './SessionListGroup.js';
 
 class SessionsList extends Component {
@@ -13,7 +22,8 @@ class SessionsList extends Component {
     super(props);
     this.state = {
       sessions: session_data.sessions,
-      max_sessions: 10,
+      max_sessions_upcoming: 3,
+      max_sessions_past: 10,
     };
   }
 
@@ -63,6 +73,50 @@ class SessionsList extends Component {
     upcoming_sessions.sort((a, b) => moment(a.date).diff(moment(b.date))); // ascending sort
     past_sessions.sort((a, b) => -moment(a.date).diff(moment(b.date)));
 
+    const n_hidden_upcoming =
+      upcoming_sessions.length - this.state.max_sessions_upcoming;
+    const n_hidden_past = past_sessions.length - this.state.max_sessions_past;
+
+    let upcoming_more_button =
+      n_hidden_upcoming > 0 ? (
+        <Row>
+          <Col style={{ textAlign: 'center' }}>
+            <Button
+              style={{ margin: 'auto' }}
+              color="primary"
+              onClick={e => {
+                this.setState({
+                  max_sessions_upcoming: this.state.max_sessions_upcoming + 5,
+                });
+              }}
+            >
+              {' '}
+              Show More Upcoming Sessions ({n_hidden_upcoming} Hidden){' '}
+            </Button>
+          </Col>
+        </Row>
+      ) : null;
+
+    let past_more_button =
+      n_hidden_past > 0 ? (
+        <Row>
+          <Col style={{ textAlign: 'center' }}>
+            <Button
+              style={{ margin: 'auto' }}
+              color="primary"
+              onClick={e => {
+                this.setState({
+                  max_sessions_past: this.state.max_sessions_past + 5,
+                });
+              }}
+            >
+              {' '}
+              Show More Past Sessions ({n_hidden_past} Hidden){' '}
+            </Button>
+          </Col>
+        </Row>
+      ) : null;
+
     return (
       <Container>
         <Row>
@@ -80,26 +134,38 @@ class SessionsList extends Component {
             </Form>
           </Col>
         </Row>
+        <hr />
         <Row>
-          <Col lg="6" xs="12">
+          <Col lg="12" xs="12">
             <Row className="vertical-align">
               <Col xs="12" lg="12">
                 <div>
-                  <h2>Upcoming Meetings</h2>
-                  <SessionListGroup sessions={upcoming_sessions} />
+                  <h2 className="center-align">Upcoming Meetings</h2>
+                  <SessionListGroup
+                    sessions={upcoming_sessions}
+                    max_sessions={this.state.max_sessions_upcoming}
+                  />
                 </div>
               </Col>
             </Row>
+            {upcoming_more_button}
           </Col>
-          <Col lg="6" xs="12">
+        </Row>
+        <br />
+        <Row>
+          <Col lg="12" xs="12">
             <Row className="vertical-align">
               <Col xs="12" lg="12">
                 <div>
-                  <h2>Past Meetings</h2>
-                  <SessionListGroup sessions={past_sessions} />
+                  <h2 className="center-align">Past Meetings</h2>
+                  <SessionListGroup
+                    sessions={past_sessions}
+                    max_sessions={this.state.max_sessions_past}
+                  />
                 </div>
               </Col>
             </Row>
+            {past_more_button}
           </Col>
         </Row>
       </Container>


### PR DESCRIPTION
Despite the presumptuous title, we should discuss if this home layout is "better"

My opinion:
**Pros**
- Sessions with a lot of info (mostly Past sessions) not as squeezed, take less space vertically
- More consistent layout with smaller screens (it always collapsed down to rows anyway)
- Avoids height asymmetries between columns (Past was always longer, but by the time you scroll past Upcoming, half the screen is blank and has no info)

**Cons**
- Need to scroll past all Upcoming sessions before getting to the first Past session
    - Two potential fixes here: 1) Add a shortcut link at the top of the page that takes you to Past Sessions or 2) set the default # of sessions shown to be small for Upcoming (I have it at 3 right now)
- Upcoming sessions without much detail (e.g., TBA sessions) take up a lot of empty space on the right side of the screen

@tgfisher lmk what you think